### PR TITLE
Fix passing the clinic_name to gigs_controller in create new gig

### DIFF
--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -13,8 +13,8 @@ class GigsController < ApplicationController
 	def create
 		@gig = Gig.new
 		@gig.doctor_id = current_doctor.id
-		# @gig.clinic_id = gigs_params[:clinic_id]
-		@gig.clinic = Clinic.find_by_name(gigs_params[:clinic_name])
+		@gig.clinic_id = gigs_params[:clinic_id]
+		# @gig.clinic = Clinic.find_by_name(gigs_params[:clinic_name])
 		@gig.price = gigs_params[:price]
 		@gig.deposit = gigs_params[:deposit]
 		@gig.checkup_duration = gigs_params[:checkup_duration]
@@ -75,7 +75,7 @@ class GigsController < ApplicationController
 	private
 	def gigs_params
 		# params.require(:gig).permit(:clinic_id,:price,:deposit,:checkup_duration,:id)
-		params.require(:gig).permit(:clinic_name,:price,:deposit,:checkup_duration,:id)
+		params.require(:gig).permit(:clinic_id,:price,:deposit,:checkup_duration,:id)
 	end
 	def getWeekDay
 		@days = [["1","Thứ Hai"],

--- a/app/views/gigs/index.html.erb
+++ b/app/views/gigs/index.html.erb
@@ -17,7 +17,8 @@
           <div class="form-group">
             <label for="clinic_id">Chọn phòng khám</label>
             <div class="form-control">
-              <%= text_field_tag 'gig[clinic_name]', nil, class: 'typeahead' %>
+              <%= text_field_tag 'clinic_name', nil, class: 'typeahead' %>
+              <%= new_gig_form.hidden_field :clinic_id %>
             </div>
           </div>
 
@@ -93,7 +94,12 @@
     source: defaultClinics,
     templates: {
       suggestion: suggestion,
-      empty: ['<div>Khoong tim thay phong kham nao</div>'].join('\n'),
+      empty: ['<div>Không tìm thấy phòng khám nào</div>'].join('\n'),
     }
+  });
+
+  $('.typeahead').bind('typeahead:select', function(ev, suggestion) {
+    console.log('Selection: ' + suggestion);
+    $('#gig_clinic_id').val(suggestion.id);
   });
 </script>


### PR DESCRIPTION
Passing the clinic_name to gigs_controller in creating new gig.
doing this by bind the `typeahead:select` event to change the hidden `clinic_id` input value to the chosen clinic, in the search box.